### PR TITLE
TRITON-2325 - Update jsprim to v2.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/davepacheco/javascriptlint.git
+	url = https://github.com/TritonDataCenter/javascriptlint.git
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = https://github.com/joyent/jsstyle.git
+	url = https://github.com/TritonDataCenter/jsstyle.git

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ language, a parser that translates the language into serializable JSON, and an
 evaluator that evaluates policies and a request's context to determine whether
 to allow or deny.
 
+```js
     var aperture = require('aperture');
     var parser = aperture.createParser({
         types: aperture.types,
@@ -33,7 +34,7 @@ to allow or deny.
     };
 
     var result = evaluator.evaluate(policy, context); // true
-
+```
 
 ## Usage
 

--- a/gen/language.js
+++ b/gen/language.js
@@ -77,7 +77,8 @@ yy: {},
 symbols_: {"error":2,"Rule":3,"List":4,"Effect":5,"Conditions":6,"EOF":7,"Identifier":8,"AND":9,"LongList":10,"All":11,",":12,"CAN":13,"NOT":14,"If":15,"OrCondition":16,"IF":17,"WHEN":18,"WHERE":19,"OR":20,"AndCondition":21,"NotCondition":22,"Condition":23,"Lhs":24,"String":25,"IN":26,"(":27,"CommaSeparatedList":28,")":29,"::":30,"STRING":31,"STRING_LITERAL":32,"FUZZY_STRING":33,"REGEX_LITERAL":34,"ALL":35,"EVERYTHING":36,"ANYTHING":37,"*":38,"$accept":0,"$end":1},
 terminals_: {2:"error",7:"EOF",9:"AND",12:",",13:"CAN",14:"NOT",17:"IF",18:"WHEN",19:"WHERE",20:"OR",26:"IN",27:"(",29:")",30:"::",31:"STRING",32:"STRING_LITERAL",33:"FUZZY_STRING",34:"REGEX_LITERAL",35:"ALL",36:"EVERYTHING",37:"ANYTHING",38:"*"},
 productions_: [0,[3,6],[3,5],[3,5],[3,4],[4,1],[4,3],[4,1],[4,1],[10,6],[10,5],[10,3],[5,1],[5,2],[6,2],[6,0],[15,1],[15,1],[15,1],[16,3],[16,1],[21,3],[21,1],[22,2],[22,1],[23,3],[23,5],[23,3],[24,3],[24,1],[28,1],[28,3],[8,1],[8,1],[8,1],[8,1],[11,1],[11,1],[11,1],[11,1],[25,1],[25,1],[25,1],[25,1]],
-performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
+performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */
+/**/) {
 /* this == yyval */
 
 var $0 = $$.length - 1;
@@ -779,7 +780,8 @@ stateStackSize:function stateStackSize() {
         return this.conditionStack.length;
     },
 options: {"case-insensitive":true},
-performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START) {
+performAction: function anonymous(yy,yy_,$avoiding_name_collisions,YY_START
+/**/) {
 
 var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {
@@ -841,7 +843,7 @@ case 20:
 break;
 }
 },
-rules: [/^(?:\s+)/i,/^(?:$)/i,/^(?:AND\b)/i,/^(?:OR\b)/i,/^(?:NOT\b)/i,/^(?:CAN\b)/i,/^(?:TO\b)/i,/^(?:IF\b)/i,/^(?:WHEN\b)/i,/^(?:WHERE\b)/i,/^(?:ALL\b)/i,/^(?:EVERYTHING\b)/i,/^(?:ANYTHING\b)/i,/^(?:IN\b)/i,/^(?:::)/i,/^(?:,)/i,/^(?:\()/i,/^(?:\))/i,/^(?:(\/((([^\n\r\*\\\/\[])|(\\([^\n\r]))|(\[([^\n\r\]\\]|(\\([^\n\r])))*\]))(([^\n\r\\\/\[])|(\\([^\n\r]))|(\[([^\n\r\]\\]|(\\([^\n\r])))*\]))*)\/([a-z]*))::regexp?)/i,/^(?:"(?:(\\)["bfnrt/(\\)]|(\\)u[a-fA-F0-9]{4}|[^"(\\)])*")/i,/^(?:([^\s,():](:(?!:))?)+)/i],
+rules: [/^(?:\s+)/i,/^(?:$)/i,/^(?:AND\b)/i,/^(?:OR\b)/i,/^(?:NOT\b)/i,/^(?:CAN\b)/i,/^(?:TO\b)/i,/^(?:IF\b)/i,/^(?:WHEN\b)/i,/^(?:WHERE\b)/i,/^(?:ALL\b)/i,/^(?:EVERYTHING\b)/i,/^(?:ANYTHING\b)/i,/^(?:IN\b)/i,/^(?:::)/i,/^(?:,)/i,/^(?:\()/i,/^(?:\))/i,/^(?:(\/((([^\n\r\*\\\/\[])|(\\([^\n\r]))|(\[([^\n\r\]\\]|(\\([^\n\r])))*\]))(([^\n\r\\\/\[])|(\\([^\n\r]))|(\[([^\n\r\]\\]|(\\([^\n\r])))*\]))*)\/([a-z]*))::regexp?)/i,/^(?:"(?:(\\)["bfnrt\/(\\)]|(\\)u[a-fA-F0-9]{4}|[^"(\\)])*")/i,/^(?:([^\s,():](:(?!:))?)+)/i],
 conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],"inclusive":true}}
 };
 return lexer;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "assert-plus": "1.0.0",
         "ipaddr.js": "0.1.1",
         "moment": "2.3.1",
-        "jsprim": "0.5.1",
+        "jsprim": "2.0.2",
         "verror": "1.3.6"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aperture",
     "description": "Security policy language and evaluation engine",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "author": "Fred Kuo",
     "private": true,
     "repository": {

--- a/test/types.test.js
+++ b/test/types.test.js
@@ -219,7 +219,7 @@ test('time: validate', function (t) {
     });
 
     times = [
-        // A 24th hour is allowed only if minutes, seconds, and milliseconds are 0
+        // A 24th hour is allowed only if minutes, seconds, and ms are 0
         '2013-06-01T24:00:01',
         'asdf',
         '20',

--- a/test/types.test.js
+++ b/test/types.test.js
@@ -219,7 +219,8 @@ test('time: validate', function (t) {
     });
 
     times = [
-        '2013-06-01T24:00:00',
+        // A 24th hour is allowed only if minutes, seconds, and milliseconds are 0
+        '2013-06-01T24:00:01',
         'asdf',
         '20',
         '20:00'


### PR DESCRIPTION
Also fix unit tests for time types that fail in Node.js versions >= 5

It seems the Date object was changed in Node.js (actually in the v8 engine) in v5.0.0.

In versions v4.9.1 and earlier:
```
> new Date('2013-06-01T24:00:00')
Invalid Date
```

In versions v5.0.0 and later:

```
> new Date('2013-06-01T24:00:00')
2013-06-02T05:00:00.000Z
```

I found no mention of this change in the Node.js changelog but tracked it back to a change in v8 that landed in Node.js v5: https://github.com/ofrobots/node/blame/af58aeae4eb919d2b765fb2b0e0d90424a1fe77e/deps/v8/src/dateparser.cc#L85
  

